### PR TITLE
fix(display): show choice zone and correct school status

### DIFF
--- a/src/components/ResultsDisplay.jsx
+++ b/src/components/ResultsDisplay.jsx
@@ -36,108 +36,76 @@ const desiredSortKeysInOrder = [
 ];
 
 export const ResultsDisplay = ({ searchResults, schoolLevel }) => {
-  console.log("ResultsDisplay received props:", { searchResults, schoolLevel });
-
   const [sortConfig, setSortConfig] = useState({ key: 'distance_mi', descending: false });
   const [selectedColumns, setSelectedColumns] = useState(() => {
     const initialCols = ['display_name', ...allPossibleColumns.filter(col => col.default).map(col => col.key)];
     return [...new Set(initialCols.filter(key => key !== 'diversity_chart'))];
   });
 
-  // --- THIS MUST BE DECLARED BEFORE `schoolsToDisplay` ---
   const userResideZoneDisplayName = useMemo(() => {
-    if (!searchResults || !searchResults.results_by_zone || searchResults.results_by_zone.length === 0) {
-      return null;
-    }
-    let resideHighSchoolObject = null;
+    if (!searchResults?.results_by_zone?.length) return null;
     for (const currentZone of searchResults.results_by_zone) {
-      if (currentZone.schools && Array.isArray(currentZone.schools)) {
-        const foundSchool = currentZone.schools.find(school =>
-          school &&
-          school.reside === 'Yes' &&
-          typeof school.school_level === 'string' &&
-          school.school_level.toLowerCase() === 'high school'
-        );
-        if (foundSchool) {
-          resideHighSchoolObject = foundSchool;
-          break;
-        }
-      }
-    }
-    if (resideHighSchoolObject) {
-      if (resideHighSchoolObject.school_zone && typeof resideHighSchoolObject.school_zone === 'string') {
-        return resideHighSchoolObject.school_zone;
-      }
+      const foundSchool = currentZone.schools?.find(school =>
+        school?.reside === 'Yes' && school?.school_level?.toLowerCase() === 'high school'
+      );
+      if (foundSchool) return foundSchool.school_zone || null;
     }
     return null;
   }, [searchResults]);
 
-  // --- THIS MUST BE DECLARED AFTER `userResideZoneDisplayName` ---
+  // <<< START: NEW CODE >>>
+  const zoneDisplayText = useMemo(() => {
+    const resideZoneText = userResideZoneDisplayName 
+      ? String(userResideZoneDisplayName).toUpperCase() 
+      : null;
+
+    if (searchResults?.is_in_choice_zone && resideZoneText) {
+      return `${resideZoneText} and CHOICE ZONE`;
+    }
+    if (resideZoneText) {
+      return resideZoneText;
+    }
+    if (searchResults?.is_in_choice_zone) {
+      return 'CHOICE ZONE';
+    }
+    return 'N/A';
+  }, [userResideZoneDisplayName, searchResults?.is_in_choice_zone]);
+  // <<< END: NEW CODE >>>
+
   const schoolsToDisplay = useMemo(() => {
-    console.log("Recalculating schoolsToDisplay...");
     if (!searchResults || !searchResults.results_by_zone) {
-        console.log(" -> No searchResults or results_by_zone found.");
         return [];
     }
-
     const levelToZoneTypeMap = {
-        'Elementary': ['Elementary', 'Reside Elementary', 'Trad/Mag Elem', 'Choice Elem', 'Traditional/Magnet Elementary'],
-        'Middle': ['Middle', 'Reside Middle', 'Trad/Mag Middle', 'Choice Middle', 'Traditional/Magnet Middle'],
-        'High': ['High', 'Reside High', 'Trad/Mag High', 'Choice High', 'Traditional/Magnet High']
+        'Elementary': ['Elementary', 'Traditional/Magnet Elementary'],
+        'Middle': ['Middle', 'Traditional/Magnet Middle'],
+        'High': ['High', 'Traditional/Magnet High']
     };
-
-    const relevantZoneKeywords = levelToZoneTypeMap[schoolLevel] || [schoolLevel];
+    const relevantZoneKeywords = levelToZoneTypeMap[schoolLevel] || [];
     const filteredZones = searchResults.results_by_zone.filter(zone =>
         relevantZoneKeywords.some(keyword => zone.zone_type.includes(keyword))
     );
 
-    // --- START: NEW LOGIC USING `zone_type` ---
-
-    // 1. Flatten all schools, but add the display_type based on the zone it came from.
     const schoolsWithDisplayType = filteredZones.flatMap(zone => {
-        // Determine the displayType for all schools in this zone.
-        // Resides zones are simple names like "Elementary", "Middle", "High".
-        // Choice zones have "Magnet" in their name.
-        const isResideZone = !zone.zone_type.includes('Magnet');
-        const displayType = isResideZone ? 'Reside School' : 'Magnet/Choice Program';
-
-        // If the zone has no schools, flatMap needs an empty array.
-        if (!zone.schools) {
-            return [];
-        }
-
-        // Tag each school in this zone with the correct displayType.
-        return zone.schools.map(school => ({
-            ...school,
-            display_type: displayType
-        }));
+        if (!zone.schools) return [];
+        return zone.schools.map(school => ({ ...school }));
     });
     
-    // 2. De-duplicate the list, giving priority to the "Reside School" designation.
     const uniqueSchoolsMap = new Map();
     schoolsWithDisplayType.forEach(school => {
         const existing = uniqueSchoolsMap.get(school.school_code_adjusted);
-        // If we haven't seen this school yet, or if the new entry is a "Reside School"
-        // (overwriting a potential "Magnet/Choice" entry), then add/update it.
-        if (!existing || school.display_type === 'Reside School') {
+        if (!existing || school.display_status === 'Reside') {
             uniqueSchoolsMap.set(school.school_code_adjusted, school);
         }
     });
     let processedSchools = Array.from(uniqueSchoolsMap.values());
-    console.log(` -> Flattened and de-duplicated to ${processedSchools.length} schools.`);
 
-    // 3. Sort the final, unique list of schools.
     const { key: sortKey, descending: sortDesc } = sortConfig;
     processedSchools.sort((a, b) => {
         let vA = a[sortKey]; let vB = b[sortKey];
         const nA = vA == null; const nB = vB == null;
         if (nA && nB) return 0; if (nA) return sortDesc ? -1 : 1; if (nB) return sortDesc ? 1 : -1;
-
-        if (sortKey === 'start_end_time') {
-            vA = a['start_time'];
-            vB = b['start_time'];
-        }
-
+        if (sortKey === 'start_end_time') { vA = a['start_time']; vB = b['start_time']; }
         const numA = parseFloat(vA); const numB = parseFloat(vB); let comp = 0;
         if (!isNaN(numA) && !isNaN(numB)) {
             if (numA > numB) comp = 1; else if (numA < numB) comp = -1;
@@ -147,12 +115,7 @@ export const ResultsDisplay = ({ searchResults, schoolLevel }) => {
         }
         return sortDesc ? (comp * -1) : comp;
     });
-    // --- END: NEW LOGIC ---
-
-    console.log(` -> Processed ${processedSchools.length} schools AFTER sorting.`);
-    console.log("Final list of schools being sent to the table:", processedSchools);
     return processedSchools;
-
   }, [searchResults, schoolLevel, sortConfig]);
 
   const columnsToDisplay = useMemo(() => {
@@ -165,12 +128,10 @@ export const ResultsDisplay = ({ searchResults, schoolLevel }) => {
     const selectedOption = event.target.options[event.target.selectedIndex];
     const newKey = selectedOption.value;
     const newDesc = selectedOption.dataset.sortDesc === 'true';
-    console.log("Sort changed:", { key: newKey, descending: newDesc });
     setSortConfig({ key: newKey, descending: newDesc });
   };
 
   const handleApplySelectedColumns = (newlySelectedKeys) => {
-    console.log("Applying new columns from ColumnSelector:", newlySelectedKeys);
     setSelectedColumns(Array.isArray(newlySelectedKeys) ? newlySelectedKeys : []);
   };
 
@@ -178,43 +139,32 @@ export const ResultsDisplay = ({ searchResults, schoolLevel }) => {
     const availableSortKeys = desiredSortKeysInOrder.filter(key =>
       selectedColumns.includes(key) && allPossibleColumns.find(col => col.key === key)?.sortable
     );
-    if (availableSortKeys.length === 0) {
+    if (!availableSortKeys.length) {
       return [<option key="no-sort" value="" disabled>No sort options available</option>];
     }
     return availableSortKeys.map(key => {
       const colConfig = allPossibleColumns.find(col => col.key === key);
-      if (!colConfig) return null;
-      const displayLabel = colConfig.sortLabel || colConfig.header || colConfig.key;
-      return (
+      return colConfig ? (
         <option key={colConfig.key} value={colConfig.key} data-sort-desc={colConfig.sortDescDefault === true}>
-           {displayLabel}
+           {colConfig.sortLabel || colConfig.header || colConfig.key}
         </option>
-      );
+      ) : null;
     }).filter(Boolean);
-  }, [selectedColumns, sortConfig.key]); // sortConfig.key added to dependency array
+  }, [selectedColumns]);
 
   useEffect(() => {
     const currentSortKey = sortConfig.key;
     const isCurrentSortKeyVisible = selectedColumns.includes(currentSortKey);
-    const currentSortColConfig = allPossibleColumns.find(col => col.key === currentSortKey);
-    const isCurrentSortKeySortable = currentSortColConfig?.sortable === true;
-
+    const isCurrentSortKeySortable = allPossibleColumns.find(col => col.key === currentSortKey)?.sortable;
     if (!isCurrentSortKeyVisible || !isCurrentSortKeySortable) {
-      const newValidSortKey = desiredSortKeysInOrder.find(key => {
-        const colConfig = allPossibleColumns.find(col => col.key === key);
-        return selectedColumns.includes(key) && colConfig?.sortable;
-      });
+      const newValidSortKey = desiredSortKeysInOrder.find(key => 
+        selectedColumns.includes(key) && allPossibleColumns.find(col => col.key === key)?.sortable
+      );
       if (newValidSortKey) {
         const newColConfig = allPossibleColumns.find(col => col.key === newValidSortKey);
         if (newColConfig) {
-            console.log(`Sort key '${currentSortKey}' is no longer valid/visible. Switching to '${newValidSortKey}'.`);
-            setSortConfig({
-                key: newValidSortKey,
-                descending: newColConfig.sortDescDefault
-            });
+            setSortConfig({ key: newValidSortKey, descending: newColConfig.sortDescDefault });
         }
-      } else {
-        console.warn("No visible sortable columns available to set as default sort.");
       }
     }
   }, [selectedColumns, sortConfig.key]);
@@ -226,9 +176,11 @@ export const ResultsDisplay = ({ searchResults, schoolLevel }) => {
             <div>
                 {`Showing results for address: ${searchResults.query_address || 'N/A'} (Lat: ${searchResults.query_lat?.toFixed(5) || 'N/A'}, Lon: ${searchResults.query_lon?.toFixed(5) || 'N/A'})`}
             </div>
+            {/* <<< START: MODIFIED CODE >>> */}
             <div className={styles.zoneInfoLine}>
-              Your zone is: <strong>{String(userResideZoneDisplayName).toUpperCase()}</strong>
+              Your zone is: <strong>{zoneDisplayText}</strong>
             </div>
+            {/* <<< END: MODIFIED CODE >>> */}
         </div>
       )}
       <div className={styles.displayControlsContainer} id="display-controls-container">
@@ -243,7 +195,6 @@ export const ResultsDisplay = ({ searchResults, schoolLevel }) => {
             disabled={sortOptions.length === 0}
           >
             {sortOptions}
-            {sortOptions.length === 0 && <option value="" disabled>No sort options for visible columns</option>}
           </select>
         </div>
         <div>
@@ -252,7 +203,6 @@ export const ResultsDisplay = ({ searchResults, schoolLevel }) => {
           </button>
         </div>
       </div>
-
       <div id="results-output" className={`d-none d-md-block ${styles.tableWrapper}`}>
         {schoolsToDisplay.length > 0 ? (
           <TableView schools={schoolsToDisplay} columns={columnsToDisplay} />
@@ -260,7 +210,6 @@ export const ResultsDisplay = ({ searchResults, schoolLevel }) => {
           <p className={`${styles.noResultsText} text-muted`}>No schools found matching your criteria.</p>
         )}
       </div>
-
       <div id="results-output-cards" className={`d-md-none ${styles.cardWrapper}`}>
         {schoolsToDisplay.length > 0 ? (
           <CardView schools={schoolsToDisplay} columns={columnsToDisplay} />
@@ -268,7 +217,6 @@ export const ResultsDisplay = ({ searchResults, schoolLevel }) => {
           <p className={`${styles.noResultsText} text-muted`}>No schools found matching your criteria.</p>
         )}
       </div>
-
       <ColumnSelector
         id="customizeColumnsOffcanvas"
         title="Customize Displayed Columns"


### PR DESCRIPTION
Updates the ResultsDisplay component to consume the new  flag from the API, displaying both reside and choice zones when applicable.

This also implicitly corrects the display status for choice zone schools, as they are now correctly labeled 'Reside' by the updated API.