### PR TITLE
feat(display): show all programs for reside schools

### DIFF
--- a/src/components/TableView.module.css
+++ b/src/components/TableView.module.css
@@ -204,3 +204,25 @@ table td a.schoolNameTable:hover {
 .academiesSection {
   margin-top: 0.5rem;
 }
+
+.programSection {
+  margin-top: 1.2rem;
+  /* This is the override. It tells a multi-line block to ignore the parent's centering
+     and align itself to the top of the flex container. */
+  /* align-self: flex-start; */
+  /* This tiny padding gives the visual nudge needed to perfectly align the text with the icon's center */
+  /* padding-top: 0.1rem; */
+  position: relative;
+  top: 1px;
+}
+
+.mapIconLink {
+  margin-top: 0.05rem;
+  margin-right: 0.5rem; /* Creates space between the icon and the text */
+  font-size: 1rem;
+  color: #6c757d;
+  flex-shrink: 0; /* Prevents the icon from shrinking if text is long */
+  align-self: center; 
+}
+
+/* Ensure the text container flows correctly next to the floated icon */


### PR DESCRIPTION
Enhances the school display logic to provide more complete and cleaner information for users.

- If a school is the user's 'Reside' school, the interface now also displays any Magnet, Districtwide Pathway, or Academies of Louisville programs available at that school.
- Refactors the display logic to hide the generic 'Magnet/Choice Program' status, instead showing specific program lists like 'Magnet Program:' or 'Districtwide Pathway:'.
- Implements CSS adjustments to ensure correct vertical alignment of the map icon with both single-line statuses and multi-line program lists.