### PR TITLE
chore(testing): update cypress test_cases.json to match back-end

### DIFF
--- a/cypress/fixtures/test_cases.json
+++ b/cypress/fixtures/test_cases.json
@@ -1,715 +1,6498 @@
 [
   {
-    "zone_name": "Waggener Zone",
-    "address": "330 S Hubbards Ln, Louisville, KY 40207",
-    "expected_schools": {
-      "Elementary": [
-        { "display_name": "Alex R. Kennedy Elementary", "expected_status": "Reside" },
-        { "display_name": "Brandeis Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Breckinridge-Franklin Elementary", "expected_status": "Reside" },
-        { "display_name": "Byck Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Chenoweth Elementary", "expected_status": "Reside" },
-        { "display_name": "Coleridge-Taylor Montessori Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Dunn Elementary", "expected_status": "Satellite School" },
-        { "display_name": "Field Elementary", "expected_status": "Reside" },
-        { "display_name": "Foster Traditional Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Hawthorne Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Lincoln Elementary Performing Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "St. Matthews Elementary", "expected_status": "Reside" },
-        { "display_name": "Young Elementary", "expected_status": "Magnet/Choice Program" }
-      ],
-      "Middle": [
-        { "display_name": "Barret Traditional Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Frederick Law Olmsted Academy South", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Highland Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Meyzeek Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Noe Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "The Academy @ Shawnee Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western Middle School for the Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Westport Middle", "expected_status": "Reside" }
-      ],
-      "High": [
-        { "display_name": "Atherton High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Ballard High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Central High Magnet Career Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Eastern High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Louisville Male High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "The Academy @ Shawnee High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Waggener High", "expected_status": "Reside" },
-        { "display_name": "Western High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "duPont Manual High", "expected_status": "Magnet/Choice Program" }
-      ]
+"address": "330 South Hubbards Lane, Louisville, KY 40207",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "St Matthews Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Alex R Kennedy Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Breckinridge-Franklin Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Chenoweth Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Dunn Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Field Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Foster Traditional Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
     }
-  },
+  ],
+  "Middle": [
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Barret Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Meyzeek Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Waggener High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Ballard High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Eastern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Waggener Zone"
+},
+{
+"address": "7005 Shallow Lake Rd, Prospect, KY 40059",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Norton Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Chancey Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Dunn Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Norton Commons Elementary School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Portland Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Wilder Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Zachary Taylor Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Greathouse/Shryock Traditional",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Kammerer Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Barret Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Meyzeek Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Ballard High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Eastern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Waggener High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Ballard Zone"
+},
+{
+"address": "1779 Bolling Ave, Louisville, KY 40210",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Perry Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Cochran Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Engelhard Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "McFerran Preparatory Academy",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Hartstern Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Luhr Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Price Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Smyrna Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Carter Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Indian Trail Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Hudson Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Marion C. Moore School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Farnsley Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Johnson Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Marion C. Moore School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fern Creek High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jeffersontown High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Butler Traditional High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Moore Zone"
+},
+{
+"address": "10200 Dixie Hwy, Louisville, KY 40258",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Dixie Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Johnsontown Road Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Kennedy Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Medora Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Carter Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Stuart Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Farnsley Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Johnson Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Valley High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Doss High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Iroquois High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Pleasure Ridge Park High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Butler Traditional High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Valley Zone"
+},
+{
+"address": "8620 Preston Hwy, Louisville, KY 40219",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Blake Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Blue Lick Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Laukhuf Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Minors Lane Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Okolona Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Rangeland Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Slaughter Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Indian Trail Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Schaffner Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Knight Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Farnsley Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Johnson Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Southern High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fern Creek High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jeffersontown High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Marion C. Moore School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Butler Traditional High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Southern Zone"
+},
+{
+"address": "9619 Glenawyn Circle, Louisville, KY 40299",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Tully Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Cochrane Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Farmer Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Jeffersontown Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Perry Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Watterson Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Audubon Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Echo Trail Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jefferson County Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Newburg Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Jeffersontown High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fern Creek High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Marion C. Moore School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Jeffersontown Zone"
+},
+{
+"address": "5901 Greenwood Rd, Louisville, KY 40258",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Greenwood Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Eisenhower Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Kerrick Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "King Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Sanders Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Shacklette Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Wellington Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Wilkerson Traditional Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Carter Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Conway Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Farnsley Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Johnson Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Pleasure Ridge Park High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Doss High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Iroquois High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Valley High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Butler Traditional High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Pleasure Ridge Park Zone"
+},
+{
+"address": "6415 Outer Loop, Louisville, KY 40228",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Smyrna Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Hartstern Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Luhr Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Price Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Indian Trail Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Schaffner Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Marion C. Moore School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jefferson County Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Newburg Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Marion C. Moore School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fern Creek High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jeffersontown High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Butler Traditional High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Moore Zone"
+},
+{
+"address": "1313 Southwestern Pkwy, Louisville, KY 40211",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Wellington Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Eisenhower Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Greenwood Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Kerrick Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "King Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Sanders Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Shacklette Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Wilkerson Traditional Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Foster Traditional Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Farnsley Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jefferson County Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Newburg Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Pleasure Ridge Park High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Doss High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Iroquois High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Valley High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. Dubois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Pleasure Ridge Park Zone"
+},
+{
+"address": "1313 Southwestern Pkwy, Louisville, KY 40211",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Wellington Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Eisenhower Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Greenwood Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Kerrick Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "King Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Sanders Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Shacklette Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Wilkerson Traditional Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Foster Traditional Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Farnsley Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jefferson County Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Newburg Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Pleasure Ridge Park High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Doss High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Iroquois High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Valley High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. Dubois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Pleasure Ridge Park Zone"
+},
+{
+"address": "2118 S Preston St, Louisville, KY 40217",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Frayser Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Cane Run Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Gutermuth Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Hazelwood Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Jacob Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Mill Creek Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Rutherford Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Semple Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Foster Traditional Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Meyzeek Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jefferson County Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Newburg Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Iroquois High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Doss High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Pleasure Ridge Park High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Valley High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. Dubois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Iroquois Zone"
+},
+{
+"address": "5044 Poplar Level Rd, Louisville, KY 40219",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Rangeland Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Blake Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Blue Lick Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Laukhuf Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Minors Lane Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Okolona Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Slaughter Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Indian Trail Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Schaffner Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Thomas Jefferson Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jefferson County Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Newburg Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Southern High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fern Creek High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jeffersontown High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Marion C. Moore School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Butler Traditional High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Southern Zone"
+},
+{
+"address": "5250 Bardstown Rd, Louisville, KY 40291",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Fern Creek Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Bates Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Price Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Watterson Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Wheeler Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Wilt Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Audubon Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Newburg Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jefferson County Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Fern Creek High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jeffersontown High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Marion C. Moore School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Fern Creek Zone"
+},
+{
+"address": "5313 Sprigwood Ln, Louisville, KY 40291",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Wheeler Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Bates Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Fern Creek Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Price Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Watterson Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Wilt Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Audubon Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Carrithers Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jefferson County Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Newburg Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Fern Creek High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jeffersontown High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Marion C. Moore School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Fern Creek Zone"
+},
+{
+"address": "4320 Billtown Rd, Jeffersontown, KY 40299",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Jeffersontown Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Cochrane Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Farmer Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Perry Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Tully Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Watterson Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Audubon Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Carrithers Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jefferson County Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Newburg Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Jeffersontown High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fern Creek High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Marion C. Moore School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Jeffersontown Zone"
+},
+{
+"address": "16005 Shelbyville Rd, Louisville, KY 40245",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Atkinson Academy",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Bowen Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Greathouse/Shryock Traditional",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hite Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lowe Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Middletown Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Stopher Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Barret Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Echo Trail Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Meyzeek Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Ballard High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Eastern High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Waggener High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Eastern Zone"
+},
+{
+"address": "1418 Morton AVE, Louisville, KY 40204",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Breckinridge-Franklin Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atkinson Academy",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Portland Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Bloom Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Camp Taylor Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Shelby Academy",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Foster Traditional Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Hudson Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jefferson County Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Meyzeek Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Ballard High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Eastern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Waggener High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Atherton Zone"
+},
+{
+"address": "717 Gwendolyn St, Louisville, KY 40203",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Breckinridge-Franklin Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atkinson Academy",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Portland Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Bloom Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Camp Taylor Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Shelby Academy",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Foster Traditional Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Hudson Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Meyzeek Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jefferson County Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Ballard High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Eastern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Waggener High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Atherton Zone"
+},
+{
+"address": "608 S 40th St, Louisville, KY 40211",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "King Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Kennedy Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Maupin Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Eisenhower Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Greenwood Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Kerrick Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Sanders Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Shacklette Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Wellington Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Wilkerson Traditional Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Foster Traditional Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Hudson Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Conway Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Barret Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Meyzeek Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Pleasure Ridge Park High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Doss High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Iroquois High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Valley High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Pleasure Ridge Park Zone"
+},
+{
+"address": "1611 Lyman Johnson Dr, Louisville, KY 40211",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Kennedy Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "King Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Maupin Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Dixie Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Johnsontown Road Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Medora Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Carter Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Hudson Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Stuart Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Farnsley Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Johnson Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Valley High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Doss High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Iroquois High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Pleasure Ridge Park High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Butler Traditional High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Valley Zone"
+},
+{
+"address": "500 W Gaulbert Ave, Louisville, KY 40208",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Cochran Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Engelhard Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "McFerran Preparatory Academy",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Perry Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Goldsmith Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Indian Trail Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Klondike Lane Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Carter Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Hudson Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Farnsley Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Johnson Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fern Creek High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jeffersontown High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Marion C. Moore School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Butler Traditional High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Seneca Zone"
+},
+{
+"address": "2219 Owen St, Louisville, KY 40212",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Atkinson Academy",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Breckinridge-Franklin Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Portland Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Bowen Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Hite Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Lowe Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Middletown Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Stopher Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Greathouse/Shryock Traditional",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Hudson Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Crosby Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Barret Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Meyzeek Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Eastern High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Ballard High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Waggener High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Eastern Zone"
+},
+{
+"address": "1131 S 32nd St, Louisville, KY 40211",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Maupin Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Kennedy Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "King Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Crums Lane Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Kenwood Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Layne Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Stonestreet Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Trunnell Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Foster Traditional Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Hudson Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Stuart Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jefferson County Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Newburg Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Doss High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Iroquois High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Pleasure Ridge Park High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Valley High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Doss Zone"
+},
+{
+"address": "1686 Letterle Ave, Louisville, KY 40206",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Breckinridge-Franklin Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atkinson Academy",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Portland Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Alex R Kennedy Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Chenoweth Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Dunn Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Field Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "St Matthews Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Greathouse/Shryock Traditional",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Hudson Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Barret Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Meyzeek Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Waggener High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Ballard High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Eastern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Waggener Zone"
+},
+{
+"address": "3922 Garfield Ave, Louisville, KY 40212",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Portland Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atkinson Academy",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Breckinridge-Franklin Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Chancey Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Dunn Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Norton Commons Elementary School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Norton Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Wilder Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Zachary Taylor Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Greathouse/Shryock Traditional",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Hudson Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Kammerer Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Barret Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Meyzeek Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Ballard High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Eastern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Waggener High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Ballard Zone"
+},
+{
+"address": "2323 Millers Ln, Louisville, KY 40216",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Maupin Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Kennedy Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "King Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Auburndale Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Coral Ridge Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Fairdale Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Minors Lane Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Schaffner Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Hudson Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Lassiter Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Farnsley Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Johnson Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Doss High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Iroquois High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Pleasure Ridge Park High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Valley High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Butler Traditional High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Fairdale Zone"
+},
+{
+"address": "1421 Magazine St, Louisville, KY 40203",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Perry Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Cochran Elementary",
+      "expected_status": "Reside"
+    },
+          {
+      "display_name": "Cochrane Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Engelhard Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "McFerran Preparatory Academy",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Farmer Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Jeffersontown Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Tully Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Watterson Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Greathouse/Shryock Traditional",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Hudson Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Ramsey Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Barret Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Meyzeek Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Jeffersontown High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fern Creek High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Marion C. Moore School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Jeffersontown Zone"
+},
+{
+"address": "828 S 17th St, Louisville, KY 40210",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Perry Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Cochran Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Cochrane Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Engelhard Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "McFerran Preparatory Academy",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Farmer Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Jeffersontown Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Tully Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Watterson Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Foster Traditional Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Hudson Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Echo Trail Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Barret Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Meyzeek Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Jeffersontown High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fern Creek High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Marion C. Moore School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Jeffersontown Zone"
+},
+{
+"address": "9115 Fern Creek Rd, Louisville, KY 40291",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Fern Creek Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Bates Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Price Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Watterson Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Wheeler Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Wilt Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Audubon Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Ramsey Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jefferson County Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Newburg Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
   {
-    "zone_name": "Ballard Zone",
-    "address": "7005 Shallow Lake Rd, Prospect, KY 40059",
-    "expected_schools": {
-      "Elementary": [
-        { "display_name": "Brandeis Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Byck Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Chancey Elementary", "expected_status": "Reside" },
-        { "display_name": "Coleridge-Taylor Montessori Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Dunn Elementary", "expected_status": "Reside" },
-        { "display_name": "Greathouse/Shryock Traditional Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Hawthorne Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Lincoln Elementary Performing Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Norton Commons Elementary", "expected_status": "Reside" },
-        { "display_name": "Norton Elementary", "expected_status": "Reside" },
-        { "display_name": "Portland Elementary", "expected_status": "Reside" },
-        { "display_name": "Wilder Elementary", "expected_status": "Reside" },
-        { "display_name": "Young Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Zachary Taylor Elementary", "expected_status": "Reside" }
-      ],
-      "Middle": [
-        { "display_name": "Barret Traditional Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Frederick Law Olmsted Academy South", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Highland Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Kammerer Middle", "expected_status": "Reside" },
-        { "display_name": "Meyzeek Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Noe Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "The Academy @ Shawnee Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western Middle School for the Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Westport Middle", "expected_status": "Magnet/Choice Program" }
-      ],
-      "High": [
-        { "display_name": "Atherton High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Ballard High", "expected_status": "Reside" },
-        { "display_name": "Central High Magnet Career Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Eastern High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Louisville Male High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "The Academy @ Shawnee High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Waggener High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Western High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "duPont Manual High", "expected_status": "Magnet/Choice Program" }
-      ]
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
     }
-  },
-  {
-    "zone_name": "Atherton Zone",
-    "address": "2901 Falmouth Dr, Louisville, KY 40205",
-    "expected_schools": {
-      "Elementary": [
-        { "display_name": "Audubon Traditional Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Bloom Elementary", "expected_status": "Reside" },
-        { "display_name": "Brandeis Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Byck Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Camp Taylor Elementary", "expected_status": "Reside" },
-        { "display_name": "Coleridge-Taylor Montessori Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Hawthorne Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Lincoln Elementary Performing Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Shelby Academy", "expected_status": "Reside" },
-        { "display_name": "Young Elementary", "expected_status": "Magnet/Choice Program" }
-      ],
-      "Middle": [
-        { "display_name": "Frederick Law Olmsted Academy South", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Highland Middle", "expected_status": "Reside" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Jefferson County Traditional Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Newburg Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Noe Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "The Academy @ Shawnee Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western Middle School for the Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Westport Middle", "expected_status": "Magnet/Choice Program" }
-      ],
-      "High": [
-        { "display_name": "Atherton High", "expected_status": "Reside" },
-        { "display_name": "Ballard High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Central High Magnet Career Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Eastern High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Louisville Male High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "The Academy @ Shawnee High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Waggener High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Western High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "duPont Manual High", "expected_status": "Magnet/Choice Program" }
-      ]
+  ],
+  "High": [
+    {
+      "display_name": "Fern Creek High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jeffersontown High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Marion C. Moore School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
     }
-  },
-  {
-    "zone_name": "Seneca Zone",
-    "address": "4425 Preston Hwy, Louisville, KY 40213",
-    "expected_schools": {
-      "Elementary": [
-        { "display_name": "Audubon Traditional Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Brandeis Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Byck Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Cochran Elementary", "expected_status": "Reside" },
-        { "display_name": "Coleridge-Taylor Montessori Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Engelhard Elementary", "expected_status": "Reside" },
-        { "display_name": "Goldsmith Elementary", "expected_status": "Reside" },
-        { "display_name": "Hawthorne Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Indian Trail Elementary", "expected_status": "Reside" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Klondike Lane Elementary", "expected_status": "Reside" },
-        { "display_name": "Lincoln Elementary Performing Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "McFerran Preparatory Academy", "expected_status": "Reside" },
-        { "display_name": "Young Elementary", "expected_status": "Magnet/Choice Program" }
-      ],
-      "Middle": [
-        { "display_name": "Frederick Law Olmsted Academy South", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Highland Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Jefferson County Traditional Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Newburg Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Noe Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "The Academy @ Shawnee Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Thomas Jefferson Middle", "expected_status": "Reside" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western Middle School for the Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Westport Middle", "expected_status": "Magnet/Choice Program" }
-      ],
-      "High": [
-        { "display_name": "Atherton High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Central High Magnet Career Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Fern Creek High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Jeffersontown High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Louisville Male High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Marion C. Moore School", "expected_status": "Academies of Louisville" },
-        { "display_name": "Seneca High", "expected_status": "Reside" },
-        { "display_name": "Southern High", "expected_status": "Academies of Louisville" },
-        { "display_name": "The Academy @ Shawnee High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "duPont Manual High", "expected_status": "Magnet/Choice Program" }
-      ]
+  ]
+},
+"zone_name": "Fern Creek Zone"
+},
+{
+"address": "9906 Callie Dr, Louisville, KY",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Fairdale Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Auburndale Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Coral Ridge Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Minors Lane Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Schaffner Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
     }
-  },
-  {
-    "zone_name": "Eastern Zone",
-    "address": "12400 Old Shelbyville Rd, Louisville, KY",
-    "expected_schools": {
-      "Elementary": [
-        { "display_name": "Atkinson Academy", "expected_status": "Reside" },
-        { "display_name": "Bowen Elementary", "expected_status": "Reside" },
-        { "display_name": "Brandeis Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Byck Elementary", "expected_status": "Reside" },
-        { "display_name": "Coleridge-Taylor Montessori Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Greathouse/Shryock Traditional Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Hawthorne Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Hite Elementary", "expected_status": "Reside" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Lincoln Elementary Performing Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Lowe Elementary", "expected_status": "Reside" },
-        { "display_name": "Middletown Elementary", "expected_status": "Reside" },
-        { "display_name": "Stopher Elementary", "expected_status": "Reside" },
-        { "display_name": "Young Elementary", "expected_status": "Magnet/Choice Program" }
-      ],
-      "Middle": [
-        { "display_name": "Barret Traditional Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Crosby Middle", "expected_status": "Reside" },
-        { "display_name": "Frederick Law Olmsted Academy South", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Highland Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Meyzeek Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Noe Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "The Academy @ Shawnee Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western Middle School for the Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Westport Middle", "expected_status": "Magnet/Choice Program" }
-      ],
-      "High": [
-        { "display_name": "Atherton High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Ballard High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Central High Magnet Career Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Eastern High", "expected_status": "Reside" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Louisville Male High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "The Academy @ Shawnee High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Waggener High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Western High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "duPont Manual High", "expected_status": "Magnet/Choice Program" }
-      ]
+  ],
+  "Middle": [
+    {
+      "display_name": "Lassiter Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Farnsley Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Johnson Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
     }
-  },
-  {
-    "zone_name": "Iroquois Zone",
-    "address": "4615 Taylor Blvd, Louisville, KY",
-    "expected_schools": {
-      "Elementary": [
-        { "display_name": "Brandeis Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Byck Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Cane Run Elementary", "expected_status": "Reside" },
-        { "display_name": "Coleridge-Taylor Montessori Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Frayser Elementary", "expected_status": "Reside" },
-        { "display_name": "Gutermuth Elementary", "expected_status": "Reside" },
-        { "display_name": "Hawthorne Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Hazelwood Elementary", "expected_status": "Reside" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Jacob Elementary", "expected_status": "Reside" },
-        { "display_name": "Lincoln Elementary Performing Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Mill Creek Elementary", "expected_status": "Reside" },
-        { "display_name": "Rutherford Elementary", "expected_status": "Reside" },
-        { "display_name": "Schaffner Traditional Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Semple Elementary", "expected_status": "Reside" },
-        { "display_name": "Young Elementary", "expected_status": "Magnet/Choice Program" }
-      ],
-      "Middle": [
-        { "display_name": "Farnsley Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Frederick Law Olmsted Academy North", "expected_status": "Reside" },
-        { "display_name": "Frederick Law Olmsted Academy South", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Highland Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Johnson Traditional Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Noe Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "The Academy @ Shawnee Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western Middle School for the Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Westport Middle", "expected_status": "Magnet/Choice Program" }
-      ],
-      "High": [
-        { "display_name": "Atherton High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Butler Traditional High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Central High Magnet Career Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Doss High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Fairdale High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Iroquois High", "expected_status": "Reside" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Pleasure Ridge Park High", "expected_status": "Academies of Louisville" },
-        { "display_name": "The Academy @ Shawnee High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Valley High", "expected_status": "Academies of Louisville" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "duPont Manual High", "expected_status": "Magnet/Choice Program" }
-      ]
+  ],
+  "High": [
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Doss High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Iroquois High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Pleasure Ridge Park High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Valley High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Butler Traditional High",
+      "expected_status": "Magnet/Choice Program"
     }
-  },
-  {
-    "zone_name": "Doss Zone",
-    "address": "7601 St Andrews Church Rd, Louisville, KY 40214",
-    "expected_schools": {
-      "Elementary": [
-        { "display_name": "Brandeis Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Byck Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Carter Traditional Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Coleridge-Taylor Montessori Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Crums Lane Elementary", "expected_status": "Reside" },
-        { "display_name": "Hawthorne Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Kenwood Elementary", "expected_status": "Reside" },
-        { "display_name": "Layne Elementary", "expected_status": "Reside" },
-        { "display_name": "Lincoln Elementary Performing Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Maupin Elementary", "expected_status": "Reside" },
-        { "display_name": "Stonestreet Elementary", "expected_status": "Reside" },
-        { "display_name": "Trunnell Elementary", "expected_status": "Reside" },
-        { "display_name": "Young Elementary", "expected_status": "Magnet/Choice Program" }
-      ],
-      "Middle": [
-        { "display_name": "Farnsley Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Frederick Law Olmsted Academy South", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Highland Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Johnson Traditional Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Noe Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Stuart Academy", "expected_status": "Reside" },
-        { "display_name": "The Academy @ Shawnee Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western Middle School for the Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Westport Middle", "expected_status": "Magnet/Choice Program" }
-      ],
-      "High": [
-        { "display_name": "Atherton High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Butler Traditional High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Central High Magnet Career Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Doss High", "expected_status": "Reside" },
-        { "display_name": "Fairdale High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Iroquois High", "expected_status": "Academies of Louisville" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Pleasure Ridge Park High", "expected_status": "Academies of Louisville" },
-        { "display_name": "The Academy @ Shawnee High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Valley High", "expected_status": "Academies of Louisville" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "duPont Manual High", "expected_status": "Magnet/Choice Program" }
-      ]
+  ]
+},
+"zone_name": "Fairdale Zone"
+},
+{
+"address": "7601 St Andrews Church Rd, Louisville, KY 40214",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Trunnell Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Crums Lane Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Kenwood Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Layne Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Maupin Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Stonestreet Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Carter Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
     }
-  },
-  {
-    "zone_name": "Fairdale Zone",
-    "address": "9906 Callie Dr, Louisville, KY",
-    "expected_schools": {
-      "Elementary": [
-        { "display_name": "Auburndale Elementary", "expected_status": "Reside" },
-        { "display_name": "Brandeis Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Byck Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Coleridge-Taylor Montessori Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Coral Ridge Elementary", "expected_status": "Reside" },
-        { "display_name": "Fairdale Elementary", "expected_status": "Reside" },
-        { "display_name": "Hawthorne Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Lincoln Elementary Performing Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Minors Lane Elementary", "expected_status": "Reside" },
-        { "display_name": "Schaffner Traditional Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Young Elementary", "expected_status": "Magnet/Choice Program" }
-      ],
-      "Middle": [
-        { "display_name": "Farnsley Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Frederick Law Olmsted Academy South", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Highland Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Johnson Traditional Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Lassiter Middle", "expected_status": "Reside" },
-        { "display_name": "Noe Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "The Academy @ Shawnee Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western Middle School for the Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Westport Middle", "expected_status": "Magnet/Choice Program" }
-      ],
-      "High": [
-        { "display_name": "Atherton High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Butler Traditional High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Central High Magnet Career Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Doss High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Fairdale High", "expected_status": "Reside" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Iroquois High", "expected_status": "Academies of Louisville" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Pleasure Ridge Park High", "expected_status": "Academies of Louisville" },
-        { "display_name": "The Academy @ Shawnee High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Valley High", "expected_status": "Academies of Louisville" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "duPont Manual High", "expected_status": "Magnet/Choice Program" }
-      ]
+  ],
+  "Middle": [
+    {
+      "display_name": "Stuart Middle School",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Farnsley Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Johnson Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
     }
-  },
-  {
-    "zone_name": "Fern Creek Zone",
-    "address": "9115 Fern Creek Rd, Louisville, KY 40291",
-    "expected_schools": {
-      "Elementary": [
-        { "display_name": "Audubon Traditional Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Bates Elementary", "expected_status": "Reside" },
-        { "display_name": "Brandeis Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Byck Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Coleridge-Taylor Montessori Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Fern Creek Elementary", "expected_status": "Reside" },
-        { "display_name": "Hawthorne Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Lincoln Elementary Performing Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Price Elementary", "expected_status": "Reside" },
-        { "display_name": "Wheeler Elementary", "expected_status": "Reside" },
-        { "display_name": "Wilt Elementary", "expected_status": "Reside" },
-        { "display_name": "Young Elementary", "expected_status": "Magnet/Choice Program" }
-      ],
-      "Middle": [
-        { "display_name": "Frederick Law Olmsted Academy South", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Highland Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Jefferson County Traditional Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Newburg Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Noe Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Ramsey Middle", "expected_status": "Reside" },
-        { "display_name": "The Academy @ Shawnee Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western Middle School for the Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Westport Middle", "expected_status": "Magnet/Choice Program" }
-      ],
-      "High": [
-        { "display_name": "Atherton High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Central High Magnet Career Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Fern Creek High", "expected_status": "Reside" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Jeffersontown High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Louisville Male High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Marion C. Moore School", "expected_status": "Academies of Louisville" },
-        { "display_name": "Seneca High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Southern High", "expected_status": "Academies of Louisville" },
-        { "display_name": "The Academy @ Shawnee High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "duPont Manual High", "expected_status": "Magnet/Choice Program" }
-      ]
+  ],
+  "High": [
+    {
+      "display_name": "Doss High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Iroquois High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Pleasure Ridge Park High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Valley High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Butler Traditional High",
+      "expected_status": "Magnet/Choice Program"
     }
-  },
-  {
-    "zone_name": "Jeffersontown Zone",
-    "address": "2209 Patti Ln, Jeffersontown, KY 40299",
-    "expected_schools": {
-      "Elementary": [
-        { "display_name": "Audubon Traditional Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Brandeis Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Byck Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Cochrane Elementary", "expected_status": "Reside" },
-        { "display_name": "Coleridge-Taylor Montessori Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Dr. William H. Perry Elementary School", "expected_status": "Reside" },
-        { "display_name": "Farmer Elementary", "expected_status": "Reside" },
-        { "display_name": "Hawthorne Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Jeffersontown Elementary", "expected_status": "Reside" },
-        { "display_name": "Lincoln Elementary Performing Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Tully Elementary", "expected_status": "Reside" },
-        { "display_name": "Watterson Elementary", "expected_status": "Reside" },
-        { "display_name": "Young Elementary", "expected_status": "Magnet/Choice Program" }
-      ],
-      "Middle": [
-        { "display_name": "Echo Trail Middle", "expected_status": "Reside" },
-        { "display_name": "Frederick Law Olmsted Academy South", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Highland Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Jefferson County Traditional Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Newburg Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Noe Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "The Academy @ Shawnee Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western Middle School for the Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Westport Middle", "expected_status": "Magnet/Choice Program" }
-      ],
-      "High": [
-        { "display_name": "Atherton High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Central High Magnet Career Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Fern Creek High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Jeffersontown High", "expected_status": "Reside" },
-        { "display_name": "Louisville Male High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Marion C. Moore School", "expected_status": "Academies of Louisville" },
-        { "display_name": "Seneca High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Southern High", "expected_status": "Academies of Louisville" },
-        { "display_name": "The Academy @ Shawnee High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "duPont Manual High", "expected_status": "Magnet/Choice Program" }
-      ]
+  ]
+},
+"zone_name": "Doss Zone"
+},
+{
+"address": "4615 Taylor Blvd, Louisville, KY",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Hazelwood Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Cane Run Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frayser Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Gutermuth Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Jacob Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Mill Creek Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Rutherford Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Semple Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Schaffner Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
     }
-  },
-  {
-    "zone_name": "Moore Zone",
-    "address": "6415 Outer Loop, Louisville, KY 40228",
-    "expected_schools": {
-      "Elementary": [
-        { "display_name": "Brandeis Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Byck Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Coleridge-Taylor Montessori Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Hartstern Elementary", "expected_status": "Reside" },
-        { "display_name": "Hawthorne Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Lincoln Elementary Performing Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Luhr Elementary", "expected_status": "Reside" },
-        { "display_name": "Schaffner Traditional Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Smyrna Elementary", "expected_status": "Reside" },
-        { "display_name": "Young Elementary", "expected_status": "Magnet/Choice Program" }
-      ],
-      "Middle": [
-        { "display_name": "Frederick Law Olmsted Academy South", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Highland Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Jefferson County Traditional Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Marion C. Moore School", "expected_status": "Reside" },
-        { "display_name": "Newburg Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Noe Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "The Academy @ Shawnee Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western Middle School for the Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Westport Middle", "expected_status": "Magnet/Choice Program" }
-      ],
-      "High": [
-        { "display_name": "Atherton High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Butler Traditional High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Central High Magnet Career Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Fern Creek High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Jeffersontown High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Marion C. Moore School", "expected_status": "Reside" },
-        { "display_name": "Seneca High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Southern High", "expected_status": "Academies of Louisville" },
-        { "display_name": "The Academy @ Shawnee High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "duPont Manual High", "expected_status": "Magnet/Choice Program" }
-      ]
+  ],
+  "Middle": [
+    {
+      "display_name": "Frederick Law Olmsted Academy North",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Farnsley Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Johnson Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
     }
-  },
-  {
-    "zone_name": "Pleasure Ridge Park Zone",
-    "address": "5901 Greenwood Rd, Louisville, KY 40258",
-    "expected_schools": {
-      "Elementary": [
-        { "display_name": "Brandeis Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Byck Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Carter Traditional Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Coleridge-Taylor Montessori Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Eisenhower Elementary", "expected_status": "Reside" },
-        { "display_name": "Greenwood Elementary", "expected_status": "Reside" },
-        { "display_name": "Hawthorne Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Kerrick Elementary", "expected_status": "Reside" },
-        { "display_name": "King Elementary", "expected_status": "Reside" },
-        { "display_name": "Lincoln Elementary Performing Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Sanders Elementary", "expected_status": "Reside" },
-        { "display_name": "Shacklette Elementary", "expected_status": "Reside" },
-        { "display_name": "Wellington Elementary", "expected_status": "Reside" },
-        { "display_name": "Wilkerson Elementary", "expected_status": "Reside" },
-        { "display_name": "Young Elementary", "expected_status": "Magnet/Choice Program" }
-      ],
-      "Middle": [
-        { "display_name": "Conway Middle", "expected_status": "Reside" },
-        { "display_name": "Farnsley Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Frederick Law Olmsted Academy South", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Highland Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Johnson Traditional Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Noe Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "The Academy @ Shawnee Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western Middle School for the Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Westport Middle", "expected_status": "Magnet/Choice Program" }
-      ],
-      "High": [
-        { "display_name": "Atherton High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Butler Traditional High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Central High Magnet Career Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Doss High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Fairdale High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Iroquois High", "expected_status": "Academies of Louisville" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Pleasure Ridge Park High", "expected_status": "Reside" },
-        { "display_name": "The Academy @ Shawnee High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Valley High", "expected_status": "Academies of Louisville" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "duPont Manual High", "expected_status": "Magnet/Choice Program" }
-      ]
+  ],
+  "High": [
+    {
+      "display_name": "Iroquois High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Doss High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Pleasure Ridge Park High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Valley High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Butler Traditional High",
+      "expected_status": "Magnet/Choice Program"
     }
-  },
-  {
-    "zone_name": "Southern Zone",
-    "address": "8620 Preston Hwy, Louisville, KY 40219",
-    "expected_schools": {
-      "Elementary": [
-        { "display_name": "Blake Elementary", "expected_status": "Reside" },
-        { "display_name": "Blue Lick Elementary", "expected_status": "Reside" },
-        { "display_name": "Brandeis Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Byck Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Coleridge-Taylor Montessori Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Hawthorne Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Laukhuf Elementary", "expected_status": "Reside" },
-        { "display_name": "Lincoln Elementary Performing Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Minors Lane Elementary", "expected_status": "Satellite School" },
-        { "display_name": "Okolona Elementary", "expected_status": "Reside" },
-        { "display_name": "Rangeland Elementary", "expected_status": "Reside" },
-        { "display_name": "Schaffner Traditional Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Slaughter Elementary", "expected_status": "Reside" },
-        { "display_name": "Young Elementary", "expected_status": "Magnet/Choice Program" }
-      ],
-      "Middle": [
-        { "display_name": "Farnsley Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Frederick Law Olmsted Academy South", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Highland Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Johnson Traditional Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Knight Middle", "expected_status": "Reside" },
-        { "display_name": "Noe Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "The Academy @ Shawnee Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western Middle School for the Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Westport Middle", "expected_status": "Magnet/Choice Program" }
-      ],
-      "High": [
-        { "display_name": "Atherton High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Butler Traditional High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Central High Magnet Career Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Fern Creek High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Jeffersontown High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Marion C. Moore School", "expected_status": "Academies of Louisville" },
-        { "display_name": "Seneca High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Southern High", "expected_status": "Reside" },
-        { "display_name": "The Academy @ Shawnee High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "duPont Manual High", "expected_status": "Magnet/Choice Program" }
-      ]
+  ]
+},
+"zone_name": "Iroquois Zone"
+},
+{
+"address": "12400 Old Shelbyville Rd, Louisville, KY",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Hite Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atkinson Academy",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Bowen Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Lowe Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Middletown Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Stopher Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Greathouse/Shryock Traditional",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
     }
-  },
-  {
-    "zone_name": "Valley Zone",
-    "address": "10200 Dixie Hwy, Louisville, KY 40258",
-    "expected_schools": {
-      "Elementary": [
-        { "display_name": "Brandeis Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Byck Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Carter Traditional Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Coleridge-Taylor Montessori Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Dixie Elementary", "expected_status": "Reside" },
-        { "display_name": "Hawthorne Elementary", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Johnsontown Road Elementary", "expected_status": "Reside" },
-        { "display_name": "Kennedy Elementary", "expected_status": "Reside" },
-        { "display_name": "Lincoln Elementary Performing Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Medora Elementary", "expected_status": "Reside" },
-        { "display_name": "Young Elementary", "expected_status": "Magnet/Choice Program" }
-      ],
-      "Middle": [
-        { "display_name": "Farnsley Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Frederick Law Olmsted Academy South", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Highland Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Johnson Traditional Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Noe Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Stuart Academy", "expected_status": "Reside" },
-        { "display_name": "The Academy @ Shawnee Middle", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western Middle School for the Arts", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Westport Middle", "expected_status": "Magnet/Choice Program" }
-      ],
-      "High": [
-        { "display_name": "Atherton High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Butler Traditional High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Central High Magnet Career Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Doss High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Fairdale High", "expected_status": "Academies of Louisville" },
-        { "display_name": "Grace M. James Academy of Excellence", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Iroquois High", "expected_status": "Academies of Louisville" },
-        { "display_name": "J. Graham Brown School", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Pleasure Ridge Park High", "expected_status": "Academies of Louisville" },
-        { "display_name": "The Academy @ Shawnee High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Valley High", "expected_status": "Reside" },
-        { "display_name": "W.E.B. DuBois Academy", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "Western High", "expected_status": "Magnet/Choice Program" },
-        { "display_name": "duPont Manual High", "expected_status": "Magnet/Choice Program" }
-      ]
+  ],
+  "Middle": [
+    {
+      "display_name": "Crosby Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Barret Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Meyzeek Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
     }
-  }
+  ],
+  "High": [
+    {
+      "display_name": "Eastern High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Ballard High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Waggener High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Eastern Zone"
+},
+{
+"address": "4425 Preston Hwy, Louisville, KY 40213",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Indian Trail Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Cochran Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Engelhard Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Goldsmith Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Klondike Lane Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "McFerran Preparatory Academy",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Audubon Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Thomas Jefferson Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jefferson County Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Newburg Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fern Creek High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jeffersontown High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Marion C. Moore School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Seneca Zone"
+},
+{
+"address": "2901 Falmouth Dr, Louisville, KY 40205",
+"expected_schools": {
+  "Elementary": [
+    {
+      "display_name": "Bloom Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Camp Taylor Elementary",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Shelby Academy",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Audubon Traditional Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Brandeis Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Byck Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Coleridge-Taylor Montessori Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Hawthorne Elementary",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Lincoln Elementary Performing Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Young Elementary",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "Middle": [
+    {
+      "display_name": "Highland Middle",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Frederick Law Olmsted Academy South",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Jefferson County Traditional Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Newburg Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Noe Middle",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western Middle School for the Arts",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Westport Middle",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ],
+  "High": [
+    {
+      "display_name": "Atherton High",
+      "expected_status": "Reside"
+    },
+    {
+      "display_name": "Ballard High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Central High Magnet Career Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Dupont Manual High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Eastern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Fairdale High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Grace M James Academy of Excellence",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "J. Graham Brown School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Seneca High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Southern High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "The Academy @ Shawnee",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "W.E.B. DuBois Academy",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Waggener High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Western High",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Youth Performing Arts School",
+      "expected_status": "Magnet/Choice Program"
+    },
+    {
+      "display_name": "Louisville Male High",
+      "expected_status": "Magnet/Choice Program"
+    }
+  ]
+},
+"zone_name": "Atherton Zone"
+}
 ]


### PR DESCRIPTION
Synchronizes the Cypress test fixture (test_cases.json) with the latest 'golden record' generated by the back-end API.

This ensures that the front-end end-to-end tests are validating against the most current and accurate data, preventing false negatives caused by outdated test assertions.