### PR TITLE
feat(ui): display school tours and open houses in a modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,6 @@
     <!-- --- ADDED CDN LINKS --- -->
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-    <link rel="stylesheet" href="extensions/sticky-header/bootstrap-table-sticky-header.css">
-    <script src="extensions/sticky-header/bootstrap-table-sticky-header.js"></script>
     <!-- Bootstrap Icons CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <!-- Chart.js via CDN (with defer) -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "jcps-finder-react",
       "version": "0.0.0",
       "dependencies": {
+        "add-to-calendar-button-react": "^2.11.5",
         "chart.js": "^4.4.9",
         "chartjs-plugin-annotation": "^3.1.0",
         "react": "^19.1.0",
@@ -1387,6 +1388,34 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/add-to-calendar-button": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/add-to-calendar-button/-/add-to-calendar-button-2.11.5.tgz",
+      "integrity": "sha512-VbtW+ZTR7OlSJh/nBj9K2CcIN9GuQ1Pi5nTfHpx9EpEOAiAEUk4aX2NC46HqqcjBEa233NXQrSRnVwVhHYUQjA==",
+      "dependencies": {
+        "timezones-ical-library": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.6.7"
+      }
+    },
+    "node_modules/add-to-calendar-button-react": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/add-to-calendar-button-react/-/add-to-calendar-button-react-2.11.5.tgz",
+      "integrity": "sha512-BsdvaTSG64HH/uhlpSFBK4O1JlbtCg7mtCY63dtzXUPw/QEJQ3xAhKRGYIlkUNFLfJqQCr8xlGfDxrcSsTsIgw==",
+      "dependencies": {
+        "add-to-calendar-button": "^2.11.5"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.6.7"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -4150,6 +4179,15 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
+    "node_modules/timezones-ical-library": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/timezones-ical-library/-/timezones-ical-library-1.10.0.tgz",
+      "integrity": "sha512-aSwylC0FyyxMqMjkuaYz56HBhhooYabGT74CbTuY1uOeIcBXSQTXf+u/mTR0MWJFPQDe21REjex+4wt0OdFDpA==",
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.6.7"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
@@ -5353,6 +5391,22 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "add-to-calendar-button": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/add-to-calendar-button/-/add-to-calendar-button-2.11.5.tgz",
+      "integrity": "sha512-VbtW+ZTR7OlSJh/nBj9K2CcIN9GuQ1Pi5nTfHpx9EpEOAiAEUk4aX2NC46HqqcjBEa233NXQrSRnVwVhHYUQjA==",
+      "requires": {
+        "timezones-ical-library": "^1.10.0"
+      }
+    },
+    "add-to-calendar-button-react": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/add-to-calendar-button-react/-/add-to-calendar-button-react-2.11.5.tgz",
+      "integrity": "sha512-BsdvaTSG64HH/uhlpSFBK4O1JlbtCg7mtCY63dtzXUPw/QEJQ3xAhKRGYIlkUNFLfJqQCr8xlGfDxrcSsTsIgw==",
+      "requires": {
+        "add-to-calendar-button": "^2.11.5"
+      }
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -7288,6 +7342,11 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
+    },
+    "timezones-ical-library": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/timezones-ical-library/-/timezones-ical-library-1.10.0.tgz",
+      "integrity": "sha512-aSwylC0FyyxMqMjkuaYz56HBhhooYabGT74CbTuY1uOeIcBXSQTXf+u/mTR0MWJFPQDe21REjex+4wt0OdFDpA=="
     },
     "tinyglobby": {
       "version": "0.2.13",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "add-to-calendar-button-react": "^2.11.5",
     "chart.js": "^4.4.9",
     "chartjs-plugin-annotation": "^3.1.0",
     "react": "^19.1.0",

--- a/src/components/MarkdownLink.jsx
+++ b/src/components/MarkdownLink.jsx
@@ -1,0 +1,38 @@
+// src/components/MarkdownLink.jsx
+import React from 'react';
+import styles from './TourModal.module.css'; // We can reuse styles from the modal
+
+const MarkdownLink = ({ text }) => {
+  if (!text) {
+    return null;
+  }
+
+  // Regular expression to find a Markdown link: [text](url)
+  const markdownLinkRegex = /\[(.*?)\]\((.*?)\)/;
+  const match = text.match(markdownLinkRegex);
+
+  // If a link is found in the text
+  if (match && match[1] && match[2]) {
+    const linkText = match[1];
+    const url = match[2];
+    
+    // Find text before and after the link to display it all
+    const textBefore = text.substring(0, match.index);
+    const textAfter = text.substring(match.index + match[0].length);
+
+    return (
+      <p>
+        {textBefore}
+        <a href={url} target="_blank" rel="noopener noreferrer" className={styles.notesLink}>
+          {linkText}
+        </a>
+        {textAfter}
+      </p>
+    );
+  }
+
+  // If no link is found, just render the plain text
+  return <p>{text}</p>;
+};
+
+export default MarkdownLink;

--- a/src/components/SchoolCard.jsx
+++ b/src/components/SchoolCard.jsx
@@ -1,31 +1,36 @@
 // src/components/SchoolCard.jsx
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './SchoolCard.module.css';
 import { formatDisplayValue } from '../utils/formatters';
-import DiversityChart from './DiversityChart';   // Adjust path if necessary
-import DiversityLegend from './DiversityLegend'; // Adjust path if necessary
+import DiversityChart from './DiversityChart';
+import DiversityLegend from './DiversityLegend';
+import { TourButton } from './TourButton';
+import { TourModal } from './TourModal';
 
 export const SchoolCard = ({ school, columns }) => {
+  // <<< START: MODIFIED CODE >>>
+  // State for the modal is now managed directly by the card
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  // <<< END: MODIFIED CODE >>>
+
   const nameColConfig = columns.find(c => c.key === 'display_name');
   const diversityColConfig = columns.find(c => c.key === 'diversity_chart');
 
-
-  // Helper to check if there's any actual diversity data to display
   const hasActualDiversityData = () => {
     if (!school) return false;
     const keysToCheck = ['white_percent', 'african_american_percent', 'hispanic_percent', 'asian_percent', 'two_or_more_races_percent'];
     let hasData = keysToCheck.some(key => school[key] != null && parseFloat(school[key]) > 0);
 
-    if (!hasData) { // Check 'other_percent' calculation if primary keys are all zero
-        const processedData = {}; // Use a local object for calculation
+    if (!hasData) {
+        const processedData = {};
         keysToCheck.forEach(key => {
             const pct = school[key];
             const numPct = (pct != null && !isNaN(parseFloat(pct))) ? Number(parseFloat(pct).toFixed(2)) : 0;
-            processedData[key] = numPct; // Store in local object
+            processedData[key] = numPct;
         });
         const calculatedKnownTotal = keysToCheck.reduce((sum, key) => sum + (processedData[key] || 0), 0);
         const otherPercent = Math.max(0, 100 - parseFloat(calculatedKnownTotal.toFixed(2)));
-        if (otherPercent > 0.01) hasData = true; // Check if 'other' contributes
+        if (otherPercent > 0.01) hasData = true;
     }
     return hasData;
   };
@@ -33,75 +38,79 @@ export const SchoolCard = ({ school, columns }) => {
   const shouldShowDiversitySection = diversityColConfig && hasActualDiversityData();
 
   return (
-    <div className={`${styles.schoolCard} card mb-2 shadow-sm`}>
-      {/* Card Header (Name Section) */}
-      {nameColConfig && (
-        <div className={`${styles.cardNameBody} card-body pb-3`}>
-          <h5 className={`${styles.schoolNameTitle} card-title mb-0`}>
-            {/* Assuming formatDisplayValue handles display_name correctly */}
-            {formatDisplayValue(nameColConfig, school)}
-          </h5>
-        </div>
-      )}
-
-      {/* Card List Group for other data points */}
-      <ul className="list-group list-group-flush">
-        {columns
-          .filter(col => col.key !== 'display_name' && col.key !== 'diversity_chart') // Exclude name and diversity_chart (handled separately)
-          .map(col => {
-            let labelSpanBaseClasses = `${styles.standardListItemLabel} fw-bold small`;
-            let labelSpanClasses = labelSpanBaseClasses;
-            if (col.key === 'start_end_time') {
-              labelSpanClasses += ` ${styles.timeLabel}`;
-              labelSpanClasses += ' me-2'; 
-            } else {
-              labelSpanClasses += ' me-2'; // Default margin for other labels
-            }
-            return (
-            <li
-              key={col.key}
-              className={`${styles.standardListItem} list-group-item d-flex justify-content-between align-items-center py-3`}
-            >
-              <span className={`${styles.standardListItemLabel} me-2 fw-bold small`}>{col.header || col.key}:</span>
-              <span className={`${styles.standardListItemValue} text-end small`}>
-                {formatDisplayValue(col, school, 'card')}
-            </span>
-            </li>
-            );
-          })}
-
-        {/* --- New Dedicated Diversity Section --- */}
-        {diversityColConfig && ( // Render this list item if diversity_chart is a selected column
-          <li className={`${styles.diversityListItem} list-group-item py-4`}>
-            {shouldShowDiversitySection ? (
-              <div className="container-fluid px-0"> {/* Ensures Bootstrap grid behaves */}
-                {/* Top Row: Title and Chart */}
-                <div className="row g-1 align-items-center mb-1"> {/* Smaller gutter and margin */}
-                  <div className="col">
-                    <span className={`${styles.diversityTitle} mb-0 fw-bold small`}>{(diversityColConfig.header || 'Student Diversity') + ':'}</span>
-                  </div>
-                  <div className={`${styles.diversityChartContainer} col-auto`}> 
-                    <DiversityChart school={school} />
-                  </div>
-                </div>
-
-                {/* Bottom Row: Legend */}
-                <div className="row mt-3">
-                  <div className="col-12">
-                    <DiversityLegend school={school} />
-                  </div>
-                </div>
-              </div>
-            ) : (
-              // Display if diversity_chart is selected but no data
-              <div>
-                <h6 className="mb-1 fw-bold small">{(diversityColConfig.header || 'Student Diversity') + ':'} </h6>
-                <p className="text-muted small mb-0">No diversity data available.</p>
-              </div>
-            )}
-          </li>
+    // <<< START: MODIFIED CODE >>>
+    // Wrap the card and modal in a React Fragment
+    <>
+      <div className={`${styles.schoolCard} card mb-2 shadow-sm`}>
+        {nameColConfig && (
+          <div className={`${styles.cardNameBody} card-body pb-3`}>
+            <h5 className={`${styles.schoolNameTitle} card-title mb-0`}>
+              {formatDisplayValue(nameColConfig, school)}
+            </h5>
+          </div>
         )}
-      </ul>
-    </div>
+
+        <ul className="list-group list-group-flush">
+          {columns
+            // Filter out the specially handled sections
+            .filter(col => col.key !== 'display_name' && col.key !== 'diversity_chart')
+            .map(col => {
+              // This part for rendering standard list items is unchanged
+              return (
+              <li
+                key={col.key}
+                className={`${styles.standardListItem} list-group-item d-flex justify-content-between align-items-center py-3`}
+              >
+                <span className={`${styles.standardListItemLabel} me-2 fw-bold small`}>{col.header || col.key}:</span>
+                <span className={`${styles.standardListItemValue} text-end small`}>
+                  {formatDisplayValue(col, school, 'card')}
+              </span>
+              </li>
+              );
+            })}
+
+          {/* Dedicated Diversity Section (Unchanged) */}
+          {diversityColConfig && (
+            <li className={`${styles.diversityListItem} list-group-item py-4`}>
+              {shouldShowDiversitySection ? (
+                <div className="container-fluid px-0">
+                  <div className="row g-1 align-items-center mb-1">
+                    <div className="col">
+                      <span className={`${styles.diversityTitle} mb-0 fw-bold small`}>{(diversityColConfig.header || 'Student Diversity') + ':'}</span>
+                    </div>
+                    <div className={`${styles.diversityChartContainer} col-auto`}> 
+                      <DiversityChart school={school} />
+                    </div>
+                  </div>
+                  <div className="row mt-3">
+                    <div className="col-12">
+                      <DiversityLegend school={school} />
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div>
+                  <h6 className="mb-1 fw-bold small">{(diversityColConfig.header || 'Student Diversity') + ':'} </h6>
+                  <p className="text-muted small mb-0">No diversity data available.</p>
+                </div>
+              )}
+            </li>
+          )}
+          
+          {/* Dedicated Tour Button Section */}
+          <li className={`${styles.tourButtonCardItem} list-group-item d-flex justify-content-center py-3`}>
+            <TourButton school={school} onClick={() => setIsModalOpen(true)} />
+          </li>
+        </ul>
+      </div>
+      
+      {/* The Modal is now rendered here, controlled by this component's state */}
+      <TourModal
+        school={school}
+        show={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+      />
+    </>
+    // <<< END: MODIFIED CODE >>>
   );
 };

--- a/src/components/SchoolTableRow.jsx
+++ b/src/components/SchoolTableRow.jsx
@@ -1,19 +1,17 @@
+// src/components/SchoolTableRow.jsx
 import React from 'react';
 import { formatDisplayValue } from '../utils/formatters';
 import DiversityChart from './DiversityChart';
 import DiversityLegend from './DiversityLegend';
-import chartStyles from './DiversityChart.module.css';
-import tableStyles from './TableView.module.css';
-import styles from './TableView.module.css'; 
+import styles from './TableView.module.css';
+import { TourButton } from './TourButton';
 
-export const SchoolTableRow = ({ school, columns }) => {
-  // Helper to check for actual diversity data
+export const SchoolTableRow = ({ school, columns, onOpenModal }) => {
   const hasActualDiversityData = () => {
     if (!school) return false;
     const keysToCheck = ['white_percent', 'african_american_percent', 'hispanic_percent', 'asian_percent', 'two_or_more_races_percent'];
     let hasData = keysToCheck.some(key => school[key] != null && parseFloat(school[key]) > 0.01);
     if (hasData) return true;
-
     const knownTotal = keysToCheck.reduce((sum, key) => sum + (parseFloat(school[key]) || 0), 0);
     const otherPercent = 100 - knownTotal;
     return otherPercent > 0.01;
@@ -22,13 +20,23 @@ export const SchoolTableRow = ({ school, columns }) => {
   return (
     <tr>
       {columns.map(col => {
-        // ... (logic for other cell types remains the same)
+        // Special handling for the display_name column to include the button
+        if (col.key === 'display_name') {
+          return (
+            <td key={col.key} className={styles.displayNameCell}>
+              {formatDisplayValue(col, school)}
+              <div className={styles.tourButtonContainer}>
+                <TourButton school={school} onClick={() => onOpenModal(school)} />
+              </div>
+            </td>
+          );
+        }
+
+        // Special handling for the diversity chart
         const isDiversityChartCol = col.key === 'diversity_chart';
-        
-        // <<< START: MODIFIED CODE >>>
         if (isDiversityChartCol) {
           return (
-            <td key={col.key} className={tableStyles.diversityCell}>
+            <td key={col.key} className={styles.diversityCell}>
               {hasActualDiversityData() ? (
                 <div className={styles.diversityContainerTable}>
                   <DiversityChart school={school} variant="table" />
@@ -40,9 +48,8 @@ export const SchoolTableRow = ({ school, columns }) => {
             </td>
           );
         }
-        // <<< END: MODIFIED CODE >>>
 
-        // Existing logic for other cells
+        // Default rendering for all other columns
         const isSingleMetricPieCol = [
           'gifted_talented_percent',
           'economically_disadvantaged_percent',
@@ -51,20 +58,18 @@ export const SchoolTableRow = ({ school, columns }) => {
           'pta_membership_percent'
         ].includes(col.key);
 
-        let cellClassName = tableStyles.tableCellCustom;
+        let cellClassName = styles.tableCellCustom;
 
-        if (col.key === 'display_name') {
-            cellClassName = tableStyles.displayNameCell;
-        } else if (isSingleMetricPieCol) {
-          cellClassName = tableStyles.pieChartCell;
+        if (isSingleMetricPieCol) {
+          cellClassName = styles.pieChartCell;
         } else if (col.key === 'start_end_time') {
-          cellClassName = tableStyles.startEndTimeCol;
+          cellClassName = styles.startEndTimeCol;
         } else if (col.key === 'reading_math_proficiency') {
-          cellClassName = tableStyles.readingMathCol;
+          cellClassName = styles.readingMathCol;
         } else if (col.key === 'overall_indicator_rating') {
-          cellClassName = tableStyles.kyRatingCell;
+          cellClassName = styles.kyRatingCell;
         } else if (col.key === 'teacher_avg_years_experience') {
-          cellClassName = tableStyles.numericCellSmall;
+          cellClassName = styles.numericCellSmall;
         }
         
         return (
@@ -75,4 +80,4 @@ export const SchoolTableRow = ({ school, columns }) => {
       })}
     </tr>
   );
-}
+};

--- a/src/components/TableView.jsx
+++ b/src/components/TableView.jsx
@@ -1,22 +1,47 @@
-import React from 'react';
+// src/components/TableView.jsx
+import React, { useState } from 'react'; // <<< ADD useState
 import styles from './TableView.module.css';
-import { SchoolTableRow } from './SchoolTableRow'; // Import row component
+import { SchoolTableRow } from './SchoolTableRow';
+import { TourModal } from './TourModal'; // <<< ADD TourModal IMPORT
 
 export const TableView = ({ schools, columns }) => {
+  // <<< START: ADDED CODE >>>
+  // State to track which school's modal is currently open
+  const [modalSchool, setModalSchool] = useState(null);
+  // <<< END: ADDED CODE >>>
+
   return (
-    <table className={`table table-hover mt-3 ${styles.tableCustom}`}>
-    <thead className={`table-light ${styles.tableHeaderCustom}`}>
-        <tr>
-        {columns.map(col => <th key={col.key}>{col.header}</th>)}
-        </tr>
-    </thead>
-    <tbody>
-        {schools.map(school => (
-        // Pass school and columns data to the row component
-        <SchoolTableRow key={school.school_code_adjusted} school={school} columns={columns} />
-        ))}
-    </tbody>
-    </table>
+    // <<< START: MODIFIED CODE >>>
+    // Wrap everything in a React Fragment
+    <>
+      <table className={`table table-hover mt-3 ${styles.tableCustom}`}>
+        <thead className={`table-light ${styles.tableHeaderCustom}`}>
+            <tr>
+            {columns.map(col => <th key={col.key}>{col.header}</th>)}
+            </tr>
+        </thead>
+        <tbody>
+            {schools.map(school => (
+            // Pass the school and a function to set the modalSchool state
+            <SchoolTableRow 
+              key={school.school_code_adjusted} 
+              school={school} 
+              columns={columns} 
+              onOpenModal={setModalSchool}
+            />
+            ))}
+        </tbody>
+      </table>
+
+      {/* Render the modal here, OUTSIDE the table structure. */}
+      {/* It will only be visible if modalSchool is not null. */}
+      <TourModal
+        school={modalSchool}
+        show={!!modalSchool}
+        onClose={() => setModalSchool(null)}
+      />
+    </>
+    // <<< END: MODIFIED CODE >>>
   );
 }
 

--- a/src/components/TableView.module.css
+++ b/src/components/TableView.module.css
@@ -289,3 +289,6 @@ table td a.schoolNameTable:hover {
   justify-content: center;
   width: 100%;
 }
+.tourButtonContainer {
+  margin-top: 0.75rem;
+}

--- a/src/components/TourButton.jsx
+++ b/src/components/TourButton.jsx
@@ -1,0 +1,23 @@
+// src/components/TourButton.jsx
+import React, { useState } from 'react';
+import styles from './TourButton.module.css';
+
+export const TourButton = ({ school, onClick }) => { 
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // <<< START: MODIFIED CODE >>>
+  const tourInfo = school.open_house_data;
+  // Don't render the button if there's no info to show
+  const hasEvents = tourInfo && tourInfo.events && Object.keys(tourInfo.events).length > 0;
+  if (!tourInfo || (!tourInfo.phone && !hasEvents && !tourInfo.notes)) {
+    return null;
+  }
+  // <<< END: MODIFIED CODE >>>
+
+  return (
+    <button className={styles.tourButton} onClick={onClick}>
+      <i className="bi bi-calendar-event"></i>
+      <span>Open House & School Tours</span>
+    </button>
+  );
+};

--- a/src/components/TourButton.module.css
+++ b/src/components/TourButton.module.css
@@ -1,0 +1,61 @@
+/* src/components/TourButton.module.css */
+/* .tourButton {
+    background-color: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 5px;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #0d6efd;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+    transition: all 0.2s ease-in-out;
+  }
+  
+  .tourButton i {
+    font-size: 0.9rem;
+  }
+  
+  .tourButton:hover {
+    background-color: #e2e6ea;
+    border-color: #adb5bd;
+  } */
+
+  .tourButton {
+    /* Use the same dark green as the school name titles */
+    --brand-green: #004D40;
+    --brand-green-light-hover: #e6f3f1;
+  
+    background-color: transparent;
+    border: 0.5px solid lightgray;
+    border-radius: 8px; /* Slightly more rounded corners */
+    padding: 0.5rem 1rem; /* More padding for a better feel */
+    font-size: 0.8rem;
+    font-weight: 500; /* Bolder text */
+    color: var(--brand-green);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: 0.5rem;
+    transition: all 0.2s ease-in-out;
+  }
+  
+  .tourButton i {
+    font-size: 1rem; /* Make the icon slightly larger */
+  }
+  
+  .tourButton:hover {
+    /* background-color: var(--brand-green-light-hover); 
+    color: var(--brand-green); */
+    /* box-shadow: 0 0 0 0.25rem lightgray; */
+    background-color: lightgrey;
+    border-color: lightgrey;
+  }
+
+  .tourButton:focus {
+    box-shadow: 0 0 0 0.25rem lightgrey;
+  }

--- a/src/components/TourModal.jsx
+++ b/src/components/TourModal.jsx
@@ -1,0 +1,134 @@
+import React, { useEffect } from 'react';
+import { AddToCalendarButton } from 'add-to-calendar-button-react';
+import { formatEventDateTime } from '../utils/dateFormatter';
+import styles from './TourModal.module.css';
+import MarkdownLink from './MarkdownLink';
+
+const stripMarkdown = (text) => {
+  if (!text) return '';
+  const markdownLinkRegex = /\[(.*?)\]\((.*?)\)/g;
+  return text.replace(markdownLinkRegex, '$1');
+};
+
+export const TourModal = ({ school, show, onClose }) => {
+  useEffect(() => {
+    if (show) {
+      document.body.classList.add(styles.modalOpen);
+    } else {
+      document.body.classList.remove(styles.modalOpen);
+    }
+    return () => {
+      document.body.classList.remove(styles.modalOpen);
+    };
+  }, [show]);
+
+  if (!show) {
+    return null;
+  }
+
+  const tourInfo = school.open_house_data || {};
+  const now = new Date();
+
+  const getUpcomingEvents = (events) => {
+    if (!events || events.length === 0) return [];
+    return events
+      .filter(event => new Date(event.start) >= now)
+      .sort((a, b) => new Date(a.start) - new Date(b.start));
+  };
+
+  const upcomingOpenHouses = getUpcomingEvents(tourInfo.events?.['Open House']);
+  const upcomingTours = getUpcomingEvents(tourInfo.events?.['School Tour']);
+  const upcomingOther = getUpcomingEvents(tourInfo.events?.['Other']);
+  const hasAnyUpcomingEvents = upcomingOpenHouses.length > 0 || upcomingTours.length > 0 || upcomingOther.length > 0;
+
+  const renderEventList = (events, type) => {
+    if (!events || events.length === 0) return null;
+
+    return (
+      <div className={styles.eventSection}>
+        <h6 className={styles.eventTitle}>{type}</h6>
+        <ul className={styles.eventList}>
+          {events.map((event, index) => (
+            <li key={index} className={styles.eventListItem}>
+              <span>{formatEventDateTime(event.start, event.end)}</span>
+              
+              <div className={styles.addToCalendarWrapper} title="Add to Calendar">
+                <AddToCalendarButton
+                  name={`${event.type || 'Event'}: ${school.display_name}`}
+                  description={stripMarkdown(tourInfo.notes)}
+                  startDate={event.start.split('T')[0]}
+                  endDate={event.end ? event.end.split('T')[0] : event.start.split('T')[0]}
+                  startTime={event.start.split('T')[1].substring(0, 5)}
+                  endTime={event.end ? event.end.split('T')[1].substring(0, 5) : ''}
+                  timeZone="America/New_York"
+                  location={school.address || 'See school website for details'}
+                  options={['Google', 'Outlook.com', 'Apple']}
+                  
+                  // Use the library's built-in icon feature
+                  buttonStyle="round"
+                  styleLight="--background: #f1f1f1; --background-hover: #e2e6ea; --button-shadow: none;"
+                  styleDark="--background: #2d2d2d; --background-hover: #424242; --button-shadow: none;"
+                  size="1"
+                  listStyle='overlay'
+                  trigger='click'
+                  
+                  // Hide the library's own label
+                  hideText
+                />
+              </div>
+
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  };
+
+  let registrationInfo = null;
+  if (tourInfo.registration_link) {
+    const markdownLinkRegex = /\[(.*?)\]\((.*?)\)/;
+    const match = tourInfo.registration_link.match(markdownLinkRegex);
+    if (match) {
+      registrationInfo = { text: match[1], url: match[2] };
+    }
+  }
+
+  return (
+    <div className={styles.modalOverlay} onClick={onClose}>
+      <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <h5 className={styles.modalTitle}>{school.display_name}</h5>
+          <button onClick={onClose} className={styles.closeButton}>&times;</button>
+        </div>
+        <div className={styles.modalBody}>
+          {registrationInfo && (
+            <div className={styles.registrationSection}>
+              <a href={registrationInfo.url} target="_blank" rel="noopener noreferrer" className={styles.registrationButton}>
+                <i className="bi bi-box-arrow-up-right"></i>
+                {registrationInfo.text}
+              </a>
+            </div>
+          )}
+          {tourInfo.phone && (
+            <p className={styles.phoneInfo}>
+              <strong>Call to schedule: </strong>
+              <a href={`tel:${tourInfo.phone.replace(/\D/g, '')}`}>{tourInfo.phone}</a>
+            </p>
+          )}
+          {renderEventList(upcomingOpenHouses, 'Open Houses')}
+          {renderEventList(upcomingTours, 'School Tours')}
+          {renderEventList(upcomingOther, 'Other Events')}
+          {!hasAnyUpcomingEvents && !tourInfo.phone && (
+             <p className={styles.noEventsMessage}>There are no upcoming tours or open houses scheduled at this time. Please check back later.</p>
+          )}
+          {tourInfo.notes && (
+            <div className={styles.notesSection}>
+              <h6>Additional Information</h6>
+              <MarkdownLink text={tourInfo.notes} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TourModal.module.css
+++ b/src/components/TourModal.module.css
@@ -1,0 +1,162 @@
+/* src/components/TourModal.module.css */
+
+:global(body.modalOpen) {
+    overflow: hidden;
+}
+.modalOverlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1050;
+  }
+  
+  .modalContent {
+    background: white;
+    padding: 1.5rem;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 600px;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+  }
+  
+  .modalHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #dee2e6;
+    padding-bottom: 1rem;
+    margin-bottom: 1rem;
+  }
+  
+  .modalTitle {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+  
+  .closeButton {
+    background: transparent;
+    border: none;
+    font-size: 1.75rem;
+    font-weight: 700;
+    line-height: 1;
+    color: #000;
+    opacity: 0.5;
+    cursor: pointer;
+  }
+  .closeButton:hover {
+    opacity: 1;
+  }
+  
+  .modalBody {
+    font-size: 0.9rem;
+  }
+  
+  .phoneInfo {
+    margin-bottom: 1rem;
+    font-size: 1rem;
+  }
+  .phoneInfo a {
+    font-weight: 600;
+  }
+  
+  .eventSection {
+    margin-bottom: 1.25rem;
+  }
+  
+  .eventTitle {
+    font-weight: 700;
+    font-size: 1rem;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 0.25rem;
+    margin-bottom: 0.75rem;
+  }
+  
+  .eventList {
+    list-style: none;
+    padding-left: 0;
+  }
+  
+  .eventListItem {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 0.25rem;
+    border-bottom: 1px solid #f2f2f2;
+  }
+  .eventListItem:last-child {
+    border-bottom: none;
+  }
+  
+  .notesSection {
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid #dee2e6;
+  }
+  .notesSection h6 {
+    font-weight: 700;
+  }
+  .notesSection p {
+    margin-bottom: 0;
+    font-style: italic;
+    color: #555;
+  }
+  .noEventsMessage {
+    font-style: italic;
+    color: #6c757d; /* Bootstrap's muted text color */
+    text-align: center;
+    padding: 1rem;
+    border: 1px dashed #dee2e6;
+    border-radius: 5px;
+    margin-top: 1rem;
+  }
+  .modalBody {
+    font-size: 0.9rem;
+    max-height: 70vh; /* Max height is 70% of the viewport height */
+    overflow-y: auto; /* Show a scrollbar ONLY if content overflows */
+    padding-right: 1rem; /* Add some padding so the scrollbar doesn't overlap content */
+  }
+
+  .notesSection .notesLink {
+    font-weight: 600;
+    text-decoration: underline;
+  }
+
+  .registrationSection {
+    margin-bottom: 1.5rem;
+    text-align: center;
+  }
+  
+  .registrationButton {
+    display: inline-block;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #fff;
+    background-color: #0d6efd; /* Bootstrap primary blue */
+    border: 1px solid #0d6efd;
+    border-radius: 6px;
+    text-decoration: none;
+    transition: all 0.2s ease-in-out;
+  }
+  
+  .registrationButton:hover {
+    background-color: #0b5ed7;
+    border-color: #0a58ca;
+  }
+  
+  .registrationButton i {
+    margin-right: 0.5rem;
+  }
+  .addToCalendarWrapper .atcb-button {
+    box-shadow: none !important;
+  }
+
+  

--- a/src/utils/dateFormatter.js
+++ b/src/utils/dateFormatter.js
@@ -1,0 +1,41 @@
+// src/utils/dateFormatter.js
+
+/**
+ * Formats an ISO 8601 date string into a readable format.
+ * Example: "2025-11-18T17:30:00" -> "Tuesday, Nov 18, 2025 from 5:30 PM"
+ * @param {string} startTimeIso - The ISO 8601 start time.
+ * @param {string} endTimeIso - The optional ISO 8601 end time.
+ * @returns {string} A formatted, human-readable date/time string.
+ */
+export function formatEventDateTime(startTimeIso, endTimeIso) {
+    if (!startTimeIso) return "Date not specified";
+  
+    const startDate = new Date(startTimeIso);
+  
+    const options = {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    };
+  
+    let formattedString = new Intl.DateTimeFormat('en-US', options).format(startDate);
+  
+    // Remove the comma after the weekday
+    formattedString = formattedString.replace(/,([^,]*)$/, '$1');
+  
+    if (endTimeIso) {
+      const endDate = new Date(endTimeIso);
+      const endTimeString = new Intl.DateTimeFormat('en-US', {
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+      }).format(endDate);
+      formattedString += ` - ${endTimeString}`;
+    }
+  
+    return formattedString;
+  }

--- a/src/utils/formatters.jsx
+++ b/src/utils/formatters.jsx
@@ -54,9 +54,7 @@ export function formatDisplayValue(colConfig, school, viewMode = 'table') {
                     if (isHighSchool && programs.length > 0) {
                         return (
                             <details key={key} className={tableStyles.programDetails}>
-                                <summary className={tableStyles.programSummary}>
-                                    {title}:
-                                </summary>
+                                <summary className={tableStyles.programSummary}>{title}:</summary>
                                 <ul className={tableStyles.programList}>
                                     {programs.map((program, index) => <li key={index}>{program}</li>)}
                                 </ul>
@@ -74,8 +72,7 @@ export function formatDisplayValue(colConfig, school, viewMode = 'table') {
                     );
                 };
 
-                // <<< START: FINAL CORRECTED LOGIC >>>
-                // Step 1: Add the primary status ONLY if it's not a program-type that will have a more specific title.
+                // Add the primary display status ONLY if it's not a program-type
                 const statusesToExclude = ['Magnet/Choice Program', 'Academies of Louisville'];
                 if (school.display_status && !statusesToExclude.includes(school.display_status)) {
                     programDisplayElements.push(
@@ -85,33 +82,25 @@ export function formatDisplayValue(colConfig, school, viewMode = 'table') {
                     );
                 }
 
-                // Step 2: Conditionally add program lists.
+                // Conditionally add program lists
                 const shouldShowMagnetOrPathway = (school.display_status === 'Reside' || school.display_status === 'Magnet/Choice Program');
-
                 if (shouldShowMagnetOrPathway && school.magnet_programs) {
-                    const title = 'Magnet Program';
-                    const magnetSection = createProgramSection('magnet', title, school.magnet_programs);
+                    const magnetSection = createProgramSection('magnet', 'Magnet Program', school.magnet_programs);
                     if (magnetSection) programDisplayElements.push(magnetSection);
                 }
 
                 if (shouldShowMagnetOrPathway && school.districtwide_pathways_programs) {
-                    const title = 'Districtwide Pathway';
-                    const pathwaySection = createProgramSection('pathway', title, school.districtwide_pathways_programs);
+                    const pathwaySection = createProgramSection('pathway', 'Districtwide Pathway', school.districtwide_pathways_programs);
                     if (pathwaySection) programDisplayElements.push(pathwaySection);
                 }
 
-                const shouldShowAcademiesList = (
-                    school.display_status === 'Academies of Louisville' || 
-                    (school.display_status === 'Reside' && isHighSchool)
-                );
-
+                const shouldShowAcademiesList = (school.display_status === 'Academies of Louisville' || (school.display_status === 'Reside' && isHighSchool));
                 if (shouldShowAcademiesList && school.the_academies_of_louisville_programs) {
-                    const title = 'Academies of Louisville';
-                    const academySection = createProgramSection('academies', title, school.the_academies_of_louisville_programs);
+                    const academySection = createProgramSection('academies', 'Academies of Louisville', school.the_academies_of_louisville_programs);
                     if (academySection) programDisplayElements.push(academySection);
                 }
 
-                // Fallback for program-types that have no program list in the data.
+                // Fallback for program-types that have no program list in the data
                 if (programDisplayElements.length === 0 && school.display_status) {
                     programDisplayElements.push(
                         <div key="status-fallback">
@@ -119,7 +108,6 @@ export function formatDisplayValue(colConfig, school, viewMode = 'table') {
                         </div>
                     );
                 }
-                // <<< END: FINAL CORRECTED LOGIC >>>
                 
                 let mapLink = null;
                 if (school.address && school.city && school.state && school.zipcode) {
@@ -135,12 +123,12 @@ export function formatDisplayValue(colConfig, school, viewMode = 'table') {
                         { (programDisplayElements.length > 0 || mapLink) && (
                             <div className="mt-2 d-flex align-items-start mt-1">
                                 {mapLink}
-                                {programDisplayElements.length > 0 && <div>{programDisplayElements}</div>}
+                                {programDisplayElements.length > 0 && <div>{programDisplayElements.filter(Boolean)}</div>}
                             </div>
                         )}
                     </>
                 );
-            } 
+            }
             
             case 'diversity_chart': {
                 return null;


### PR DESCRIPTION
This commit introduces the front-end components required to display seasonal school tour and open house information.

- A 'TourButton' component is added to the school name column in both table and card views.
- Clicking the button opens a 'TourModal' which displays the information fetched from the API.
- The modal is scrollable, prevents background scroll, and includes a prominent registration link if available.
- Events are categorized into 'Open Houses' and 'School Tours' and are filtered to only show upcoming dates.
- An 'Add to Calendar' button is provided for each event.