### PR TITLE
Add Netlify redirects file to redirect jcpscompare.netlify.app

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,2 @@
+https://jcpscompare.netlify.app/*    https://www.explorejcps.com/:splat    301!
+


### PR DESCRIPTION
 add explicit redirect from netlify to custom domain" -m "Adds a forced 301 redirect rule to the `_redirects` file.

This rule explicitly forwards all traffic from the default Netlify subdomain (jcpscompare.netlify.app) to the primary custom domain 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `_redirects` to force 301 from `https://jcpscompare.netlify.app/*` to `https://www.explorejcps.com/:splat`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 383ceaef2040157e8a184dd9f7d6091117186a7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->